### PR TITLE
change default sidebar sorting to recent

### DIFF
--- a/src/selectors/entities/preferences.js
+++ b/src/selectors/entities/preferences.js
@@ -195,7 +195,7 @@ const defaultSidebarPrefs = {
     grouping: 'by_type',
     unreads_at_top: 'true',
     favorite_at_top: 'true',
-    sorting: 'alpha',
+    sorting: 'recent',
 };
 
 export const getSidebarPreferences = createSelector(


### PR DESCRIPTION
#### Summary
Changing the default default sidebar sorting to `recent` instead of current `alpha`

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-4578
