### PR TITLE
list unread channels on top within group

### DIFF
--- a/src/selectors/entities/channels.js
+++ b/src/selectors/entities/channels.js
@@ -148,6 +148,13 @@ export function filterChannels(unreadIds: Array<string>, favoriteIds: Array<stri
         });
     }
 
+    if (!unreadsAtTop) {
+        const readChannels = channels.filter((id) => {
+            return !unreadIds.includes(id);
+        });
+        channels = channels.push(...readChannels);
+    }
+
     return channels;
 }
 


### PR DESCRIPTION
#### Summary
When unread channels are shown within groups, this will now show unread channels on top within the corresponding group, e.g. public, private.

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-4640

#### Checklist
